### PR TITLE
Gitignore Binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # UE4
+Binaries/*
 Build/*
 Intermediate/*


### PR DESCRIPTION
### Summary

Adds the `Binaries` directory to the gitignore, which is generated on Linux when building the module. 