### PR TITLE
Depth Camera Brush (BSP) Visibility

### DIFF
--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -480,6 +480,8 @@ void UVisionComponent::ShowFlagsLit(FEngineShowFlags &ShowFlags) const
 void UVisionComponent::ShowFlagsPostProcess(FEngineShowFlags &ShowFlags) const
 {
 	ShowFlagsBasicSetting(ShowFlags);
+	ShowFlags.SetBSP(true);
+	ShowFlags.SetBSPTriangles(true);
 	ShowFlags.SetPostProcessing(true);
 	ShowFlags.SetPostProcessMaterial(true);
 


### PR DESCRIPTION
### Summary

Adds show flags to the depth camera to display [Brushes](https://docs.unrealengine.com/en-US/Engine/Actors/Brushes/index.html) (BSP).