### PR TITLE
Fix DisableTFPublishing Editor Crash

### DIFF
--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -170,7 +170,7 @@ void UVisionComponent::BeginPlay()
 		_TFPublisher->Init(rosinst->ROSIntegrationCore, 
                            TEXT("/tf"), 
                            TEXT("tf2_msgs/TFMessage"));
-    _TFPublisher->Advertise();
+ 		_TFPublisher->Advertise();
 
 		_CameraInfoPublisher = NewObject<UTopic>(UTopic::StaticClass());
 		_CameraInfoPublisher->Init(rosinst->ROSIntegrationCore, 

--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -166,15 +166,11 @@ void UVisionComponent::BeginPlay()
 	UROSIntegrationGameInstance* rosinst = Cast<UROSIntegrationGameInstance>(GetOwner()->GetGameInstance());
 	if (rosinst)
 	{
-		if (!DisableTFPublishing)
-		{
-			UE_LOG(LogTemp, Warning, TEXT("ROSIntegrationGameInstance available. Setting up ROS Topics ..."));
-			_TFPublisher = NewObject<UTopic>(UTopic::StaticClass());
-			_TFPublisher->Init(rosinst->ROSIntegrationCore, 
-	                           TEXT("/tf"), 
-	                           TEXT("tf2_msgs/TFMessage"));
-			_TFPublisher->Advertise();
-		}
+		_TFPublisher = NewObject<UTopic>(UTopic::StaticClass());
+		_TFPublisher->Init(rosinst->ROSIntegrationCore, 
+                           TEXT("/tf"), 
+                           TEXT("tf2_msgs/TFMessage"));
+    _TFPublisher->Advertise();
 
 		_CameraInfoPublisher = NewObject<UTopic>(UTopic::StaticClass());
 		_CameraInfoPublisher->Init(rosinst->ROSIntegrationCore, 

--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -319,10 +319,9 @@ void UVisionComponent::TickComponent(float DeltaTime,
 
 	if (!DisableTFPublishing) {
     // Start advertising TF only if it has yet to advertise.
-    if (!TFAdvertising)
+    if (!_TFPublisher->IsAdvertising())
     {
       _TFPublisher->Advertise();
-      TFAdvertising = true;
     }
 		TSharedPtr<ROSMessages::tf2_msgs::TFMessage> TFImageFrame(new ROSMessages::tf2_msgs::TFMessage());
 		ROSMessages::geometry_msgs::TransformStamped TransformImage;
@@ -365,9 +364,8 @@ void UVisionComponent::TickComponent(float DeltaTime,
 		_TFPublisher->Publish(TFOpticalFrame);
 	}
   // Stop advertising if TF has been disabled and is already advertising.
-  else if (TFAdvertising) {
+  else if (_TFPublisher->IsAdvertising()) {
     _TFPublisher->Unadvertise();
-    TFAdvertising = false;
   }
 
 	// Construct and publish CameraInfo

--- a/Source/ROSIntegrationVision/Public/VisionComponent.h
+++ b/Source/ROSIntegrationVision/Public/VisionComponent.h
@@ -77,7 +77,7 @@ private:
   TArray<FColor> ObjectColors;
   TMap<FString, uint32> ObjectToColor;
   uint32 ColorsUsed;
-  bool Running, Paused;
+  bool Running, Paused, TFAdvertising;
   
   void ShowFlagsBasicSetting(FEngineShowFlags &ShowFlags) const;
   void ShowFlagsLit(FEngineShowFlags &ShowFlags) const;

--- a/Source/ROSIntegrationVision/Public/VisionComponent.h
+++ b/Source/ROSIntegrationVision/Public/VisionComponent.h
@@ -77,7 +77,7 @@ private:
   TArray<FColor> ObjectColors;
   TMap<FString, uint32> ObjectToColor;
   uint32 ColorsUsed;
-  bool Running, Paused, TFAdvertising;
+  bool Running, Paused;
   
   void ShowFlagsBasicSetting(FEngineShowFlags &ShowFlags) const;
   void ShowFlagsLit(FEngineShowFlags &ShowFlags) const;


### PR DESCRIPTION
### Bug Steps to Reproduce

- Attach a Vision component to an Actor with `DisableTFPublishing` initialized to **true**
- In the Editor, toggle `DisableTFPublishing` 

### Fix 

The crash is caused by an uninitialized `_TFPublisher` which is referenced when `DisableTFPublishing` is set to **false** after initialized with **true**