### PR TITLE
Fix Referenced Directory Warnings

### DIFF
--- a/Source/ROSIntegrationVision/ROSIntegrationVision.Build.cs
+++ b/Source/ROSIntegrationVision/ROSIntegrationVision.Build.cs
@@ -2,10 +2,7 @@
 
 using UnrealBuildTool;
 
-using System;
 using System.IO;
-
-
 
 public class ROSIntegrationVision : ModuleRules
 {
@@ -14,73 +11,51 @@ public class ROSIntegrationVision : ModuleRules
         get { return ModuleDirectory; }
     }
 
-
     private string ThirdPartyPath
     {
         get { return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/")); }
     }
 
     public ROSIntegrationVision (ReadOnlyTargetRules Target) : base(Target)
-	{
-		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-
-        
-        PublicIncludePaths.AddRange(
-			new string[] {
-				"ROSIntegrationVision/Public",
-                "ROSIntegration/Public"
-				// ... add public include paths required here ...
-			}
-			);
-				
-		
-		PrivateIncludePaths.AddRange(
-			new string[] {
-				"ROSIntegrationVision/Private",
-                "ROSIntegration/Public"
-				// ... add other private include paths required here ...
-			}
-			);
-			
-		
-		PublicDependencyModuleNames.AddRange(
-			new string[]
-			{
-				"Core",
-                "Sockets",
-                "Networking",
-                "ROSIntegration"
-				// ... add other public dependencies that you statically link with here ...
-			}
-			);
-			
-		
-		PrivateDependencyModuleNames.AddRange(
-			new string[]
-			{
-                "Core",
-				"CoreUObject",
-				"Engine",
-                "RenderCore",
-				"Slate",
-				"SlateCore",
-                "Sockets",
-                "Networking",
-                "ROSIntegration"
-				// ... add private dependencies that you statically link with here ...	
-			}
-			);
-		
-		
-		DynamicallyLoadedModuleNames.AddRange(
-			new string[]
-			{
-				// ... add any modules that your module loads dynamically here ...
-			}
-			);
-
-
-
-
+  	{
+    		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+            
+        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+    		
+    		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
+    		
+    		PublicDependencyModuleNames.AddRange(
+    			new string[]
+    			{
+    				"Core",
+            "Sockets",
+            "Networking",
+            "ROSIntegration"
+    				// ... add other public dependencies that you statically link with here ...
+    			}
+  			);
+    			
+    		PrivateDependencyModuleNames.AddRange(
+    			new string[]
+    			{
+            "Core",
+    				"CoreUObject",
+    				"Engine",
+            "RenderCore",
+    				"Slate",
+    				"SlateCore",
+            "Sockets",
+            "Networking",
+            "ROSIntegration"
+    				// ... add private dependencies that you statically link with here ...	
+    			}
+  			);
+  		
+    		DynamicallyLoadedModuleNames.AddRange(
+    			new string[]
+    			{
+    				// ... add any modules that your module loads dynamically here ...
+    			}
+  			);
     }
 }

--- a/Source/ROSIntegrationVision/ROSIntegrationVision.Build.cs
+++ b/Source/ROSIntegrationVision/ROSIntegrationVision.Build.cs
@@ -6,56 +6,56 @@ using System.IO;
 
 public class ROSIntegrationVision : ModuleRules
 {
-    private string ModulePath
-    {
-        get { return ModuleDirectory; }
-    }
+  private string ModulePath
+  {
+    get { return ModuleDirectory; }
+  }
 
-    private string ThirdPartyPath
-    {
-        get { return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/")); }
-    }
+  private string ThirdPartyPath
+  {
+    get { return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/")); }
+  }
 
-    public ROSIntegrationVision (ReadOnlyTargetRules Target) : base(Target)
-  	{
-    		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-            
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
-    		
-    		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
-    		
-    		PublicDependencyModuleNames.AddRange(
-    			new string[]
-    			{
-    				"Core",
-            "Sockets",
-            "Networking",
-            "ROSIntegration"
-    				// ... add other public dependencies that you statically link with here ...
-    			}
-  			);
-    			
-    		PrivateDependencyModuleNames.AddRange(
-    			new string[]
-    			{
-            "Core",
-    				"CoreUObject",
-    				"Engine",
-            "RenderCore",
-    				"Slate",
-    				"SlateCore",
-            "Sockets",
-            "Networking",
-            "ROSIntegration"
-    				// ... add private dependencies that you statically link with here ...	
-    			}
-  			);
-  		
-    		DynamicallyLoadedModuleNames.AddRange(
-    			new string[]
-    			{
-    				// ... add any modules that your module loads dynamically here ...
-    			}
-  			);
-    }
+  public ROSIntegrationVision (ReadOnlyTargetRules Target) : base(Target)
+  {
+    PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+    PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+
+    PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
+
+    PublicDependencyModuleNames.AddRange(
+      new string[]
+      {
+        "Core",
+        "Sockets",
+        "Networking",
+        "ROSIntegration"
+        // ... add other public dependencies that you statically link with here ...
+      }
+    );
+
+    PrivateDependencyModuleNames.AddRange(
+      new string[]
+      {
+        "Core",
+        "CoreUObject",
+        "Engine",
+        "RenderCore",
+        "Slate",
+        "SlateCore",
+        "Sockets",
+        "Networking",
+        "ROSIntegration"
+        // ... add private dependencies that you statically link with here ...	
+      }
+    );
+
+    DynamicallyLoadedModuleNames.AddRange(
+      new string[]
+      {
+        // ... add any modules that your module loads dynamically here ...
+      }
+    );
+  }
 }


### PR DESCRIPTION
#### Summary

Warnings similar to the following appear when compiling the plugin,

```
/home/USER/repos/PROJECT/Plugins/ROSIntegrationVision/Source/ROSIntegrationVision/ROSIntegrationVision.Build.cs: warning: Referenced directory '/home/USER/repos/unreal/Engine/Source/ROSIntegrationVision/Public' does not exist.
```

#### Fix

`AddRange` for Public and Private includes were changed to the following;

```
PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
```

Additionally, the includes from `ROSIntegration` inside `AddRange` were removed since the plugin already has a Public and Private dependency on the module. 