### PR TITLE
Migrate Plugin type to Runtime

### DIFF
--- a/ROSIntegrationVision.uplugin
+++ b/ROSIntegrationVision.uplugin
@@ -17,7 +17,7 @@
 	"Modules": [
 		{
 			"Name": "ROSIntegrationVision",
-			"Type": "Developer",
+			"Type": "Runtime",
 			"LoadingPhase": "Default"
 		}
 	],

--- a/Source/ROSIntegrationVision/ROSIntegrationVision.Build.cs
+++ b/Source/ROSIntegrationVision/ROSIntegrationVision.Build.cs
@@ -42,8 +42,6 @@ public class ROSIntegrationVision : ModuleRules
         "CoreUObject",
         "Engine",
         "RenderCore",
-        "Slate",
-        "SlateCore",
         "Sockets",
         "Networking",
         "ROSIntegration"


### PR DESCRIPTION
#### Summary 

Migrates the plugin to Runtime for use with shipping builds.

Removes the unused Slate dependencies
