### PR TITLE
UE4.25 Support

### DIFF
--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -512,7 +512,6 @@ void UVisionComponent::ReadImageCompressed(UTextureRenderTarget2D *RenderTarget,
 	static IImageWrapperModule& ImageWrapperModule = FModuleManager::LoadModuleChecked<IImageWrapperModule>(FName("ImageWrapper"));
 	static TSharedPtr<IImageWrapper> ImageWrapper = ImageWrapperModule.CreateImageWrapper(EImageFormat::PNG);
 	ImageWrapper->SetRaw(RawImageData.GetData(), RawImageData.GetAllocatedSize(), Width, Height, ERGBFormat::BGRA, 8);
-	const TArray<uint8>& ImgData = ImageWrapper->GetCompressed();
 }
 
 void UVisionComponent::ToColorImage(const TArray<FFloat16Color> &ImageData, uint8 *Bytes) const

--- a/Source/ROSIntegrationVision/Public/ROSIntegrationVision.h
+++ b/Source/ROSIntegrationVision/Public/ROSIntegrationVision.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 class FROSIntegrationVisionModule : public IModuleInterface
 {
@@ -24,7 +24,7 @@ public:
 		return FModuleManager::LoadModuleChecked< FROSIntegrationVisionModule >("ROSIntegrationVision");
 	}
 
-	/** 
+	/**
 	* Checks to see if this module is loaded and ready.  It is only valid to call Get() if IsAvailable() returns true.
 	*
 	* @return True if the module is loaded and ready to use


### PR DESCRIPTION
### Bugs

Explicit include for ModuleManager is required for UE4.25.1.

TArray64 is returned explicitly by [ImageWrapper->GetCompressed](https://github.com/EpicGames/UnrealEngine/blob/f8f4b403eb682ffc055613c7caf9d2ba5df7f319/Engine/Source/Runtime/ImageWrapper/Private/ImageWrapperBase.cpp#L48)

### Fixes

1. Explicit include for ModuleManager
2. Removal of the ImageWrapper->GetCompressed call inside UVisionComponent::ReadImageCompressed as it is unused.
