### PR TITLE
Fix save failure for VisionActor

### DIFF
--- a/Source/ROSIntegrationVision/Public/VisionComponent.h
+++ b/Source/ROSIntegrationVision/Public/VisionComponent.h
@@ -38,11 +38,11 @@ public:
     int32 ServerPort;
     
   // The cameras for color, depth and objects;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
-	  USceneCaptureComponent2D * Color;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
+    USceneCaptureComponent2D * Color;
+  UPROPERTY(Transient, EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
   	USceneCaptureComponent2D * Depth;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
     USceneCaptureComponent2D * Object;
   
   UPROPERTY(BlueprintReadWrite, Category = "Vision Component")
@@ -50,13 +50,13 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Vision Component")
     FString ImageOpticalFrame = TEXT("/unreal_ros/image_optical_frame");
     
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
     UTopic * CameraInfoPublisher;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
     UTopic * DepthPublisher;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
    UTopic * ImagePublisher;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
    UTopic * TFPublisher;
 
 protected:


### PR DESCRIPTION
Added transient property to scene capture components and topic to address failure to save
UE4 version: 4.25.1

Problem description:
I added a bare `VisionActor` to the scene and tried to save the level, UE4 had the following compliant message:
![save_bug_rosintegrationvision](https://user-images.githubusercontent.com/8027401/88467519-eaa79b80-cea5-11ea-8570-c97de3aa56f0.png)

Resolution:
Added `Transient` property specifier to the blocking items under `VisionComponent` to prevent them from being serialized when saving. Now the scene with an instantiated `VisionActor` can be saved without problems.