### PR TITLE
Fixed some compilation failures and warnings for UE4.25 on Windows platform

### DIFF
--- a/Source/ROSIntegrationVision/Private/VisionActor.h
+++ b/Source/ROSIntegrationVision/Private/VisionActor.h
@@ -23,6 +23,6 @@ public:
 	// Called every frame
 	virtual void Tick(float DeltaSeconds) override;
 
-	UPROPERTY(EditAnywhere, Category = "Vision Actor")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Vision Actor")
 		UVisionComponent * vision; 
 };

--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -746,7 +746,11 @@ void UVisionComponent::convertDepth(const uint16_t *in, __m128 *out) const
 	for (size_t i = 0; i < size; ++i, in += 4, ++out)
 	{
     // Divide by 100 here in order to convert UU (cm) into ROS units (m)
-		*out = _mm_cvtph_ps(_mm_set_epi16(
-        0, 0, 0, 0, *(in + 3), *(in + 2), *(in + 1), *(in + 0))) / 100;
+		*out = _mm_cvtph_ps(
+			_mm_div_epi16(
+				_mm_set_epi16(0, 0, 0, 0, *(in + 3), *(in + 2), *(in + 1), *(in + 0)),
+				_mm_set_epi16(100, 100, 100, 100, 100, 100, 100, 100)
+			)
+		);// / 100;
 	}
 }

--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -13,6 +13,10 @@
 #include "sensor_msgs/Image.h"
 #include "tf2_msgs/TFMessage.h"
 
+#include "PacketBuffer.h"
+#include "ROSIntegrationGameInstance.h"
+#include "StopTime.h"
+
 #include "EngineUtils.h"
 #include "IImageWrapper.h"
 #include "IImageWrapperModule.h"

--- a/Source/ROSIntegrationVision/Public/VisionComponent.h
+++ b/Source/ROSIntegrationVision/Public/VisionComponent.h
@@ -38,11 +38,11 @@ public:
     int32 ServerPort;
     
   // The cameras for color, depth and objects;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
 	  USceneCaptureComponent2D * Color;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
   	USceneCaptureComponent2D * Depth;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
     USceneCaptureComponent2D * Object;
   
   UPROPERTY(BlueprintReadWrite, Category = "Vision Component")

--- a/Source/ROSIntegrationVision/Public/VisionComponent.h
+++ b/Source/ROSIntegrationVision/Public/VisionComponent.h
@@ -38,11 +38,11 @@ public:
     int32 ServerPort;
     
   // The cameras for color, depth and objects;
-  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
 	  USceneCaptureComponent2D * Color;
-  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
   	USceneCaptureComponent2D * Depth;
-  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, BlueprintReadWrite, Category = "Vision Component")
     USceneCaptureComponent2D * Object;
   
   UPROPERTY(BlueprintReadWrite, Category = "Vision Component")
@@ -50,13 +50,13 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Vision Component")
     FString ImageOpticalFrame = TEXT("/unreal_ros/image_optical_frame");
     
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
     UTopic * CameraInfoPublisher;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
     UTopic * DepthPublisher;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
    UTopic * ImagePublisher;
-  UPROPERTY(EditAnywhere, Category = "Vision Component")
+  UPROPERTY(Transient, EditAnywhere, Category = "Vision Component")
    UTopic * TFPublisher;
 
 protected:


### PR DESCRIPTION
- Fixed compilation failure of UVisionComponent::convertDepth.
- Added some #include's to make VSCode IntelliSense happy.
- Added BP R/W accessibility for vision component in VisionActor for conveniently changing camera parameters using BP on the fly.
This PR fixes #28 